### PR TITLE
Release gravity-devs/liquidity v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,11 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
-## [v1.4.5](https://github.com/tendermint/liquidity/releases) - 2022.01.30
+## [v1.4.6](https://github.com/tendermint/liquidity/releases) - 2022.02
+
+* [\#473](https://github.com/tendermint/liquidity/pull/473) build: bump cosmos-sdk to v0.45.1
+
+## [v1.4.5](https://github.com/tendermint/liquidity/releases/tag/v1.4.5) - 2022.02.03
 
 * [\#471](https://github.com/tendermint/liquidity/pull/471) build: bump cosmos-sdk to v0.45.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,22 +33,27 @@ Types of changes (Stanzas):
 Ref: https://keepachangelog.com/en/1.0.0/
 -->
 
+<!-- markdown-link-check-disable -->
+
 # Changelog
 
 ## [Unreleased]
 
-## [v1.4.6](https://github.com/tendermint/liquidity/releases) - 2022.02
+## [v1.5.0](https://github.com/tendermint/liquidity/releases/tag/v1.5.0) - 2022.02.23
 
-* [\#473](https://github.com/tendermint/liquidity/pull/473) build: bump cosmos-sdk to v0.45.1
+### State Machine Breaking
+* [\#466](https://github.com/tendermint/liquidity/pull/466) fix: exclude circuit breaking logic for MsgWithdrawWithinBatch
+* [\#473](https://github.com/tendermint/liquidity/pull/473) (sdk) Bump SDK version to [v0.45.1](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.45.1)
 
-## [v1.4.5](https://github.com/tendermint/liquidity/releases/tag/v1.4.5) - 2022.02.03
+## [v1.4.6](https://github.com/tendermint/liquidity/releases/tag/v1.4.6) - 2022.02.23
 
-* [\#471](https://github.com/tendermint/liquidity/pull/471) build: bump cosmos-sdk to v0.45.0
+* [\#475](https://github.com/tendermint/liquidity/pull/475) (sdk) Bump SDK version to [v0.44.6](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.44.6)
+
+## [v1.4.5](https://github.com/tendermint/liquidity/releases/tag/v1.4.5) - 2022.01.30
+* Unusable release
 
 ## [v1.4.4](https://github.com/tendermint/liquidity/releases/tag/v1.4.4) - 2022.01.26
-
-* [\#469](https://github.com/tendermint/liquidity/pull/469) build: bump cosmos-sdk to v0.44.5
-* [\#466](https://github.com/tendermint/liquidity/pull/466) fix: exclude circuit breaking logic for MsgWithdrawWithinBatch
+* Unusable release
 
 ## [v1.4.2](https://github.com/tendermint/liquidity/releases/tag/v1.4.2) - 2021.11.11
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ For details, see the [Liquidity Module Light Paper](doc/LiquidityModuleLightPape
 Requirement | Notes
 ----------- | -----------------
 Go version  | Go1.15 or higher
-Cosmos SDK  | v0.45.0 or higher
+Cosmos SDK  | v0.45.1 or higher
 
 ### Get Liquidity Module source code
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ go 1.15
 module github.com/gravity-devs/liquidity
 
 require (
-	github.com/cosmos/cosmos-sdk v0.45.0
+	github.com/cosmos/cosmos-sdk v0.45.1
 	github.com/gogo/protobuf v1.3.3
 	github.com/golang/mock v1.6.0
 	github.com/golang/protobuf v1.5.2

--- a/go.sum
+++ b/go.sum
@@ -179,8 +179,8 @@ github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfc
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cosmos/btcutil v1.0.4 h1:n7C2ngKXo7UC9gNyMNLbzqz7Asuf+7Qv4gnX/rOdQ44=
 github.com/cosmos/btcutil v1.0.4/go.mod h1:Ffqc8Hn6TJUdDgHBwIZLtrLQC1KdJ9jGJl/TvgUaxbU=
-github.com/cosmos/cosmos-sdk v0.45.0 h1:DHD+CIRZ+cYgiLXuTEUL/aprnfPsWSwaww/fIZEsZlk=
-github.com/cosmos/cosmos-sdk v0.45.0/go.mod h1:XXS/asyCqWNWkx2rW6pSuen+EVcpAFxq6khrhnZgHaQ=
+github.com/cosmos/cosmos-sdk v0.45.1 h1:PY79YxPea5qlRLExRnzg8/rT1Scc8GGgRs22p7DX99Q=
+github.com/cosmos/cosmos-sdk v0.45.1/go.mod h1:XXS/asyCqWNWkx2rW6pSuen+EVcpAFxq6khrhnZgHaQ=
 github.com/cosmos/go-bip39 v0.0.0-20180819234021-555e2067c45d/go.mod h1:tSxLoYXyBmiFeKpvmq4dzayMdCjCnu8uqmCysIGBT2Y=
 github.com/cosmos/go-bip39 v1.0.0 h1:pcomnQdrdH22njcAatO0yWojsUnCO3y2tNoV1cb6hHY=
 github.com/cosmos/go-bip39 v1.0.0/go.mod h1:RNJv0H/pOIVgxw6KS7QeX2a0Uo0aKUlfhZ4xuwvCdJw=


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

This PR for release liquidity v1.5.0 of gravity-devs

- build: bump cosmos-sdk to v0.45.1 https://github.com/tendermint/liquidity/pull/473

Note: The release includes state-breaking changes with bump sdk, but it's to match the sdk version of gaia v07-Theta PR https://github.com/cosmos/gaia/pull/1219, However, if an additional version of [sdk 0.45.x](https://github.com/cosmos/cosmos-sdk/commits/release/v0.45.x) is released before the gaia PR is completed, we may need another bump, so we postpone and watch the merge and release for a while.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
